### PR TITLE
macOS: ignore .DS_Store file when repacking

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,6 +145,8 @@ class OP1Repack:
         files = os.listdir(path)
         tar = tarfile.open(target, 'w')
         for file in files:
+            if file.startswith("."):
+                continue
             file_path = os.path.join(path, file)
             self.logger.debug('Adding "{}" to archive.'.format(file_path))
             # Remove the subfolder name so that the archive won't contain the subfolder.


### PR DESCRIPTION
Otherwise, the repacked firmware blob diverges unnecessarily from the original.